### PR TITLE
OpenBSD does not have alloca.h

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #if defined(__WIN32) || defined(WIN32) || defined(_MSC_VER)
 #include <malloc.h>
-#else
+#elsif !defined(__OpenBSD__)
 #include <alloca.h>
 #endif
 


### PR DESCRIPTION
The functionality is included in stdlib.h and other already included headers.

It builds the three examples successfully.