### PR TITLE
Fix frame family example

### DIFF
--- a/examples/frame-family/frame-family.c
+++ b/examples/frame-family/frame-family.c
@@ -1,6 +1,7 @@
 #include "SDL.h"
 #include "KW_gui.h"
-#include "KW_button.h"
+#include "KW_frame.h"
+#include "KW_label.h"
 #include "KW_renderdriver_sdl2.h"
 
 int main(int argc, char ** argv) {
@@ -14,11 +15,10 @@ int main(int argc, char ** argv) {
   KW_Font * font;
   KW_Rect framegeom, labelgeom;
   KW_Widget * frame;
-  int i = 0;  
   
   SDL_Init(SDL_INIT_EVERYTHING);
   SDL_CreateWindowAndRenderer(320, 240, 0, &window, &renderer);
-  SDL_SetRenderDrawColor(renderer, 100, 100, 100, 1);
+  SDL_SetRenderDrawColor(renderer, 200, 100, 100, 1);
   driver = KW_CreateSDL2RenderDriver(renderer, window);
   /* load tileset */
   
@@ -28,15 +28,15 @@ int main(int argc, char ** argv) {
   gui = KW_Init(driver, set);
   font = KW_LoadFont(driver, "Fontin-Regular.ttf", 12);
   KW_SetFont(gui, font);
-
   
   framegeom.x = 10, framegeom.y = 10, framegeom.w = 160, framegeom.h = 120;
   labelgeom = framegeom; labelgeom.x = labelgeom.y = 0;
 
   /* create 10 frames and 10 labels */
   frame = NULL;
-  for (i = 0; i < 10; i++) {
-    frame = KW_CreateButton(gui, frame, "Yay", &framegeom);
+  for (int i = 0; i < 10; i++) {
+    frame = KW_CreateFrame(gui, frame, &framegeom);
+    KW_CreateLabel(gui, frame, "Yay", &labelgeom);
   }
 
   while (!SDL_QuitRequested()) {
@@ -48,9 +48,9 @@ int main(int argc, char ** argv) {
   
   /* free stuff */
   KW_Quit(gui);
-  TTF_CloseFont(font);
-  SDL_FreeSurface(set);
-  TTF_Quit();
+  KW_ReleaseFont(driver, font);
+  KW_ReleaseSurface(driver, set);
+  KW_ReleaseRenderDriver(driver);
   SDL_Quit();
   
   return 0;


### PR DESCRIPTION
Notes:

- Changed code to use KiWi functions as much as possible (comments were  left as is)
- Unlike what the name suggests, this demo creates buttons, not frames with labels, therefore that has been fixed
- The background color of the built demo did not match the screenshot, so that's been fixed, too
- As there was a recent change to remove C89 compatibility for examples, I've removed the declaration for `i`