### PR TITLE
Add missing `extern "C"`.

### DIFF
--- a/src/KW_bool.h
+++ b/src/KW_bool.h
@@ -7,9 +7,17 @@
  * A helper enumeration with true and false values
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
   KW_FALSE = 0,
   KW_TRUE = 1
 } KW_bool;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_button_internal.h
+++ b/src/KW_button_internal.h
@@ -3,11 +3,18 @@
 
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct KW_Button {
   KW_Widget * labelwidget; /* the label inside the button frame */
   KW_Texture * normal;
   KW_Texture * over;
 } KW_Button;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_checkbox.h
+++ b/src/KW_checkbox.h
@@ -9,6 +9,10 @@
 
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \brief Creates a new checkbox.
  * \details Checkboxes listen to the mouseup event, when they happen either in the label
@@ -36,5 +40,9 @@ extern DECLSPEC KW_Widget * KW_GetCheckboxLabel(KW_Widget * widget);
  * \details You might want to destroy this widget if you have no use to it.
  */
 extern DECLSPEC KW_Widget * KW_SetCheckboxLabel(KW_Widget * widget, KW_Widget * label);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_editbox.h
+++ b/src/KW_editbox.h
@@ -34,6 +34,10 @@
 #include "KW_widget.h"
 #include "SDL_ttf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern DECLSPEC KW_Widget * KW_CreateEditbox(KW_GUI * gui, KW_Widget * parent,
                                              const char * text,
                                              const KW_Rect * geometry);
@@ -71,5 +75,9 @@ extern DECLSPEC KW_bool KW_WasEditboxTextColorSet(KW_Widget * widget);
  * \param   color The color to assign to the editbox.
  */
 extern DECLSPEC void KW_SetEditboxTextColor(KW_Widget * widget, KW_Color color);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_editbox_internal.h
+++ b/src/KW_editbox_internal.h
@@ -4,6 +4,10 @@
 #include "SDL.h"
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct KW_Edtibox {
   KW_Widget * widget;         /* the widget we pertain to */
   
@@ -49,5 +53,8 @@ void EditboxTextInput(KW_Widget * widget, const char * text);
 void EditboxKeyDown(KW_Widget * widget, SDL_Keycode key, SDL_Scancode sym);
 void EditboxFontChanged(KW_GUI * gui, void * priv, KW_Font * font);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_frame_internal.h
+++ b/src/KW_frame_internal.h
@@ -4,6 +4,10 @@
 #include "SDL.h"
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct KW_Frame {
   KW_Texture * framerender;
 } KW_Frame;
@@ -13,5 +17,9 @@ void RenderFrame(KW_Widget * widget);
 void PaintFrame(KW_Widget * widget, const KW_Rect * absolute, void * data);
 void DestroyFrame(KW_Widget * widget);
 void FrameGeometryChanged(KW_Widget * widget, const KW_Rect * newrect, const KW_Rect * old);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_gui_internal.h
+++ b/src/KW_gui_internal.h
@@ -4,6 +4,10 @@
 #include "KW_widget.h"
 #include "KW_renderdriver.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void (*GUIHandler)(void);
 
 typedef enum KW_GUIEventHandlerType {
@@ -44,8 +48,8 @@ struct KW_GUI {
 void AddGUIHandler(KW_GUI * gui, KW_GUIEventHandlerType handlertype, GUIHandler handler, void * priv);
 void RemoveGUItHandler(KW_GUI * gui, KW_GUIEventHandlerType handlertype, GUIHandler handler, void * priv);
 
-
-
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_label_internal.h
+++ b/src/KW_label_internal.h
@@ -5,6 +5,10 @@
 #include "SDL_ttf.h"
 #include "KW_label.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef
 struct KW_Label {
   char * text;
@@ -35,5 +39,9 @@ void PaintLabel(KW_Widget * widget, const KW_Rect * absolute, void * data);
 void RenderLabelText(KW_Widget * widget);
 void DestroyLabel(KW_Widget * widget);
 void LabelFontChanged(KW_GUI * gui, void * data, KW_Font * font);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_rect.h
+++ b/src/KW_rect.h
@@ -27,6 +27,10 @@
 
 #include "KW_macros.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The KW_Rect struct represents a rectangle.
  */
@@ -170,5 +174,9 @@ extern DECLSPEC void KW_MarginRect(const KW_Rect * outer, KW_Rect * inner, int m
 #define KW_PRINTRECT(command, rect) { \
   command("%dx%d+%dx%d\n", (rect).x, (rect).y, (rect).w, (rect).h); \
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_renderdriver.h
+++ b/src/KW_renderdriver.h
@@ -20,6 +20,10 @@
 #include "KW_rect.h"
 #include "KW_bool.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct KW_Texture {
   void * texture;
 } KW_Texture;
@@ -221,5 +225,9 @@ extern DECLSPEC void KW_SetClipRect(KW_RenderDriver * driver, const KW_Rect * cl
 extern DECLSPEC void KW_ReleaseRenderDriver(KW_RenderDriver * driver);
 extern DECLSPEC void KW_UTF8TextSize(KW_RenderDriver * driver, KW_Font * font, const char * text, unsigned * width, unsigned * height);
 extern DECLSPEC unsigned int KW_GetPixel(KW_RenderDriver * driver, KW_Surface * surface, unsigned x, unsigned y);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_renderdriver_sdl2.h
+++ b/src/KW_renderdriver_sdl2.h
@@ -1,10 +1,14 @@
 #ifndef KW_RENDERDRIVER_SDL2
 #define KW_RENDERDRIVER_SDL2
 
+#include "KW_macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct SDL_Renderer;
 struct SDL_Window;
-
-#include "KW_macros.h"
 
 /**
  * \brief   Creates a SDL2 based KiWi render driver
@@ -13,7 +17,7 @@ struct SDL_Window;
  * \param   window The SDL2 window
  * \returns A KW_RenderDriver instance
  */
-extern DECLSPEC struct KW_RenderDriver * KW_CreateSDL2RenderDriver(struct SDL_Renderer * renderer, struct SDL_Window * window);
+extern DECLSPEC struct KW_RenderDriver *KW_CreateSDL2RenderDriver(struct SDL_Renderer *renderer, struct SDL_Window *window);
 
 /**
  * \brief   Gives back the SDL2 renderer used to create this RenderDriver
@@ -21,7 +25,7 @@ extern DECLSPEC struct KW_RenderDriver * KW_CreateSDL2RenderDriver(struct SDL_Re
  * \returns The SDL_Renderer used
  * \sa      KW_RenderDriverGetSDL2Window
  */
-extern DECLSPEC struct SDL_Renderer * KW_RenderDriverGetSDL2Renderer(struct KW_RenderDriver * driver);
+extern DECLSPEC struct SDL_Renderer *KW_RenderDriverGetSDL2Renderer(struct KW_RenderDriver *driver);
 
 /**
  * \brief   Gives back the SDL2 window used to create this RenderDriver
@@ -29,7 +33,10 @@ extern DECLSPEC struct SDL_Renderer * KW_RenderDriverGetSDL2Renderer(struct KW_R
  * \returns The SDL_Window used
  * \sa      KW_RenderDriverGetSDL2Renderer
  */
-extern DECLSPEC struct SDL_Window * KW_RenderDriverGetSDL2Window(struct KW_RenderDriver * driver);
+extern DECLSPEC struct SDL_Window *KW_RenderDriverGetSDL2Window(struct KW_RenderDriver *driver);
 
+#ifdef __cplusplus
+}
 #endif
 
+#endif

--- a/src/KW_scrollbox.h
+++ b/src/KW_scrollbox.h
@@ -4,6 +4,11 @@
 #include "KW_gui.h"
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /**
  * \brief   Creates a frame that can scroll its children widgets.
  * \details Unless specified otherwise, the scrollbox will scroll its children
@@ -33,5 +38,9 @@ extern DECLSPEC void KW_ScrollboxVerticalScroll(KW_Widget * scrollbox, int amoun
  * \param   amount The amount of pixels to vertically scroll.
  */
 extern DECLSPEC void KW_ScrollboxHorizontalScroll(KW_Widget * scrollbox, int amount);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_scrollbox_internal.h
+++ b/src/KW_scrollbox_internal.h
@@ -3,6 +3,11 @@
 
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 typedef struct KW_Scrollbox {
   KW_Widget   * root;
   KW_Widget   * outer;
@@ -24,5 +29,8 @@ void HorizontalBarDrag(KW_Widget * widget, int x, int y, int xrel, int yrel);
 void ChildrenChange(KW_Widget * widget, KW_WidgetChildrenChangeEvent what, KW_Widget * children);
 void RootScrollboxGeometryChange(KW_Widget * widget, const KW_Rect * newgeom, const KW_Rect * oldgeom);
 void RenderScrollboxFrame(KW_Scrollbox * sb);
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_toggle.h
+++ b/src/KW_toggle.h
@@ -33,6 +33,10 @@
 #include "KW_gui.h"
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * \brief Creates a toggle button that can be checked or not checked.
  * \details The toggle occupies by default the column 12, lines 0 through 12 in the tileset.
@@ -56,5 +60,9 @@ extern DECLSPEC KW_bool KW_IsToggleChecked(KW_Widget * widget);
  * \param checked Pass KW_TRUE to make it checked or KW_FALSE otherwise
  */
 extern DECLSPEC void KW_SetToggleChecked(KW_Widget * widget, KW_bool checked);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/KW_widget_internal.h
+++ b/src/KW_widget_internal.h
@@ -3,6 +3,10 @@
 
 #include "KW_widget.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct KW_GUI;
 
 typedef enum KW_WidgetEventHandlerType {
@@ -64,5 +68,9 @@ struct KW_Widget {
 KW_Widget * AllocWidget();
 
 void FreeWidget(KW_Widget * widget, int freechildren);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -1,5 +1,9 @@
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* is c the start of a utf8 sequence? */
 #define isutf(c) (((c)&0xC0)!=0x80)
 
@@ -55,3 +59,6 @@ int u8_strlen(const char *s);
 
 int u8_is_locale_utf8(char *locale);
 
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Hi!

Using the lib on a C++ project was impossible due the missing `extern "C"`. This patch is meant to fix that.