### PR TITLE
Fix bug where the KW_EventWatcher was still active after KW_Quit.

### DIFF
--- a/src/KW_eventwatcher.c
+++ b/src/KW_eventwatcher.c
@@ -126,6 +126,7 @@ void KeyDown(KW_GUI * gui, SDL_Keycode key, SDL_Scancode scan) {
 /* to capture mouse movements, clicks, types, etc */
 int KW_EventWatcher(void * data, SDL_Event * event) {
   KW_GUI * gui = (KW_GUI *) data;
+  SDL_assert(gui->evqueuesize < 1024);
   SDL_LockMutex(gui->evqueuelock);    
   gui->evqueue[(gui->evqueuesize)++] = *event;
   SDL_UnlockMutex(gui->evqueuelock);  

--- a/src/KW_gui.c
+++ b/src/KW_gui.c
@@ -61,6 +61,7 @@ KW_Surface * KW_GetTilesetSurface(KW_GUI * gui) {
 
 
 void KW_Quit(KW_GUI * gui) {
+  SDL_DelEventWatch(KW_EventWatcher, (void*)gui);
   KW_DestroyWidget(gui->rootwidget, 1);
   KW_ReleaseFont(gui->renderer, gui->defaultfont);
   KW_ReleaseTexture(gui->renderer, gui->tilesettexture);


### PR DESCRIPTION
This bug caused the stack to grow too much and crashed the system. I also put an assert to check if the event queue has room enough, but a better solution may be necessary.