### PR TITLE
Fix bug where the events watcher was still active after KW_Quit.

### DIFF
--- a/src/KW_gui.c
+++ b/src/KW_gui.c
@@ -61,6 +61,7 @@ KW_Surface * KW_GetTilesetSurface(KW_GUI * gui) {
 
 
 void KW_Quit(KW_GUI * gui) {
+  SDL_DelEventWatch(KW_EventWatcher, (void*)gui);
   KW_DestroyWidget(gui->rootwidget, 1);
   KW_ReleaseFont(gui->renderer, gui->defaultfont);
   KW_ReleaseTexture(gui->renderer, gui->tilesettexture);


### PR DESCRIPTION
This bug caused the stack to grow too much and crashed the system, as it continued to put new events but I did not processed them anymore.