### PR TITLE
Changed 'include' line from SDL_Image.h to SDL_image.h

### DIFF
--- a/examples/custom-render/custom-render.c
+++ b/examples/custom-render/custom-render.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "SDL.h"
-#include "SDL_Image.h"
+#include "SDL_image.h"
 #include "KW_gui.h"
 #include "KW_frame.h"
 #include "KW_label.h"


### PR DESCRIPTION
Using Ubuntu 18.04:

Header file on this system named "SDL_image.h", not "SDL_Image.h"; only
seems to affect the 'custom-render' example.  Changed code to reflect
actual name of header file so that the build doesn't fail.

(Recommend adding a way to exclude examples from build so library is
usable without them.)