### PR TITLE
various fixes to allow it to be used as a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ project(KiWi)
 cmake_minimum_required(VERSION 2.8)
 
 # Point to our own cmake modules
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-modules)
+set(KIWI_ROOT ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "")
+list(APPEND CMAKE_MODULE_PATH ${KIWI_ROOT}/cmake-modules)
 
 # Define this as top-level
 set(KIWI_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/resources/kiwires.cmake
+++ b/resources/kiwires.cmake
@@ -5,7 +5,7 @@ macro(kiwires)
     cmake_parse_arguments(KIWIRES "" "${ONEVALUEARGS}" "${MULTIVALUEARGS}" ${ARGN})
     try_compile(FILE2C_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/file2c.c COPY_FILE "${CMAKE_BINARY_DIR}/file2c${CMAKE_EXECUTABLE_SUFFIX}")
     execute_process(
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${KIWI_ROOT}
             COMMAND
                 ${CMAKE_BINARY_DIR}/file2c${CMAKE_EXECUTABLE_SUFFIX}
                     ${CMAKE_CURRENT_BINARY_DIR}/${KIWIRES_HEADER}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(SDL2 REQUIRED)
 find_package(SDL2_ttf REQUIRED)
 find_package(SDL2_image REQUIRED)
 
-include(${CMAKE_SOURCE_DIR}/resources/kiwires.cmake)
+include(${KIWI_ROOT}/resources/kiwires.cmake)
 
 set(API_HEADERS
   KW_gui.h


### PR DESCRIPTION
This creates a KIWI_ROOT variable that replaces CMAKE_SOURCE_DIR in a few places.
This allows it to be built via the add_subdirectory() function