### PR TITLE
Clicking on the first half of a widget's icon does not register as a …

### DIFF
--- a/src/KW_label_internal.c
+++ b/src/KW_label_internal.c
@@ -70,7 +70,7 @@ void PaintLabel(KW_Widget * widget, const KW_Rect * absolute, void * data) {
   };
 
   /* apply horizontal offset and icon offset */
-  dst.x += label->hoffset;
+  dst.x += label->hoffset+label->iconclip.w/2;
 
   /* calculate y according to valign */
   switch (label->valign) {

--- a/src/KW_label_internal.c
+++ b/src/KW_label_internal.c
@@ -70,7 +70,7 @@ void PaintLabel(KW_Widget * widget, const KW_Rect * absolute, void * data) {
   };
 
   /* apply horizontal offset and icon offset */
-  dst.x += label->hoffset+label->iconclip.w/2;
+  dst.x += label->hoffset + label->iconclip.w / 2;
 
   /* calculate y according to valign */
   switch (label->valign) {


### PR DESCRIPTION
…keypress, this should fix it